### PR TITLE
用urllib2代替urllib

### DIFF
--- a/examples/test_python3.py
+++ b/examples/test_python3.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 __author__ = 'kevin'
 
-import urllib.request
+import urllib2
 from pyheatmap.heatmap import HeatMap
 
 
@@ -10,8 +10,9 @@ def main():
     data = []
     # download test data
     url = "https://raw.github.com/oldj/pyheatmap/master/examples/test_data.txt"
-    for line in urllib.request.urlopen(url):
-        line_str = str(line, encoding='utf-8').split("\n")
+    for line in urllib2.urlopen(url):
+        #, encoding='utf-8'
+        line_str = str(line).split("\n")
         for ln in line_str:
             if ',' in ln:
                 a = ln.split(",")


### PR DESCRIPTION
when I use urllib.request.urlopen, it will show "No module named urllib.request..."Error..., so I replace it with urllib2.
